### PR TITLE
Replace CMD by ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN \
   ln -s /srv/var/casperjs/bin/casperjs /usr/bin/casperjs
 
 # Default command
-CMD ["/usr/bin/casperjs"]
+ENTRYPOINT ["/usr/bin/casperjs"]


### PR DESCRIPTION
So as casperjs is the main executable when the image is ran (every image arguments are appended after the ENTRYPOINT).